### PR TITLE
Adds removeArea function to customAreaRenderer

### DIFF
--- a/src/components/Area/Area.tsx
+++ b/src/components/Area/Area.tsx
@@ -8,7 +8,8 @@ export const Area: FunctionComponent<IAreaProps> = ({
     showHandles,
     globalAreaStyle,
     customAreaRenderer,
-    areaNumber
+    areaNumber,
+    removeArea
 }) => {
     const localStyle = {
         top: `${area.y}${area.unit}`,
@@ -33,7 +34,7 @@ export const Area: FunctionComponent<IAreaProps> = ({
             data-wrapper="wrapper"
         >
             {customAreaRenderer
-                ? customAreaRenderer({ ...area, areaNumber })
+                ? customAreaRenderer({ ...area, areaNumber, removeArea })
                 : null}
             {showHandles ? <Handles /> : null}
         </div>

--- a/src/components/Area/types.ts
+++ b/src/components/Area/types.ts
@@ -7,5 +7,6 @@ export interface IAreaProps {
     onCropStart: (event: PointerEvent<HTMLDivElement>) => void;
     showHandles: boolean;
     customAreaRenderer?: CustomAreaRenderer;
-    areaNumber: number 
+    areaNumber: number;
+    removeArea: (index: number) => void;
 }

--- a/src/components/AreaSelector/AreaSelector.stories.tsx
+++ b/src/components/AreaSelector/AreaSelector.stories.tsx
@@ -20,6 +20,19 @@ export const AreaSelectExample: Story<{
             return (
                 <div key={areaProps.areaNumber}>
                     {customRenderExampleText} - {areaProps.areaNumber}
+                    <button
+                        style={{
+                            position: 'absolute',
+                            bottom: '-30px',
+                            left: '50%',
+                            transform: 'translateX(-50%)'
+                        }}
+                        onClick={() =>
+                            areaProps.removeArea(areaProps.areaNumber - 1)
+                        }
+                    >
+                        remove
+                    </button>
                 </div>
             );
         }

--- a/src/components/AreaSelector/AreaSelector.tsx
+++ b/src/components/AreaSelector/AreaSelector.tsx
@@ -398,6 +398,10 @@ export const AreaSelector: FunctionComponent<IAreaSelectorProps> = ({
         });
     };
 
+    const removeArea = (index: number) => {
+        onChange([...areas.slice(0, index), ...areas.slice(index + 1)]);
+    };
+
     return (
         <div
             ref={wrapperRef}
@@ -429,6 +433,7 @@ export const AreaSelector: FunctionComponent<IAreaSelectorProps> = ({
                     globalAreaStyle={globalAreaStyle}
                     customAreaRenderer={customAreaRenderer}
                     areaNumber={index + 1}
+                    removeArea={removeArea}
                 />
             ))}
             {debug ? <Debugger areas={areas} /> : null}

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface IArea extends IRectangle {
 
 export interface IAreaRendererProps extends Omit<IArea, 'customAreaRenderer'> {
     areaNumber: number;
+    removeArea: (index: number) => void;
 }
 
 export interface IPixelArea extends IArea {


### PR DESCRIPTION
Adds a `removeArea` function to the customAreaRenderer to make it easier to remove an area. 

The current function takes the index of the item that should be removed. This way you can remove the current area in the custom renderer (see updated example), but you could also decide to be more creative and do whatever you feel like. If this should not be possible it could be rewritten to make a binding to the current area (in `Area.tsx`) so that it's only possible to remove the current one in the custom renderer. Which would also remove the need for applying an argument to the function.